### PR TITLE
Added support for h1 tags & rebranded for magnet.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Magnet.me fork of the [Quill Rich Text Editor](http://quilljs.com/)
+
+This is the Magnet.me specific fork of the Quill editor. It is based upon quill 0.20, with the following changes:
+
+- Support for H1 tags
+- Only 1 line styling is allowed at a time
+
+This fork is intended solely for the use on [Magnet.me](http://magnet.me). Anyone is free to use this fork, but we will not provide any support for it.
+
 # [Quill Rich Text Editor](http://quilljs.com/) [![Build Status](https://travis-ci.org/quilljs/quill.svg?branch=master)](http://travis-ci.org/quilljs/quill)
 
 [![Webdriver Test Status](https://saucelabs.com/browser-matrix/quill-master.svg)](https://saucelabs.com/u/quill)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-lodash": "~0.4.0",
     "grunt-protractor-runner": "~2.0.0",
     "grunt-sauce-connect-launcher": "~0.3.0",
-    "harp": "~0.17.0",
+    "harp": "^0.20.1",
     "http-proxy": "~1.11.1",
     "istanbul": "~0.3.5",
     "jasmine-core": "~2.3.4",
@@ -53,6 +53,7 @@
     "rich-text": "~2.0.0",
     "stylify": "~1.0.0",
     "stylus": "~0.51.1",
+    "terraform": "^0.13.1",
     "through": "~2.3.7",
     "watchify": "~3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "quill",
+  "name": "mm-quill",
   "version": "0.20.0",
-  "description": "Cross browser rich text editor",
+  "description": "Magnet.me specific fork of quill, a cross browser rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
-  "homepage": "http://quilljs.com",
   "contributors": [
     "Byron Milligan <byronner@gmail.com>",
-    "Keegan Poppen <keegan.poppen@gmail.com>"
+    "Keegan Poppen <keegan.poppen@gmail.com>",
+    "Tiddo Langerak <tiddo@magnet.me>"
   ],
   "main": "index.js",
   "devDependencies": {
@@ -66,10 +66,10 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/quilljs/quill"
+    "url": "https://github.com/Magnetme/mm-quill"
   },
   "bugs": {
-    "url": "https://github.com/quilljs/quill/issues"
+    "url": "https://github.com/Magnetme/mm-quill/issues"
   },
   "scripts": {
     "prepublish": "grunt dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mm-quill",
-  "version": "0.20.0",
+  "version": "1.0.0",
   "description": "Magnet.me specific fork of quill, a cross browser rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "editor",
     "rich text",
     "wysiwyg"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "http://npm.internal.magnet.me:4873/"
+  }
 }

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -78,6 +78,12 @@ class Format
       parentTag: 'OL'
       tag: 'LI'
 
+    h1:
+      type: Format.types.LINE
+      clearOnNewline : true,
+      tag: 'H1'
+
+
 
   constructor: (@config) ->
 

--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -67,11 +67,11 @@ class Line extends LinkedList.Node
       return unless format?
       # TODO reassigning @node might be dangerous...
       if format.isType(Format.types.LINE)
-        if format.config.exclude and @formats[format.config.exclude]
-          excludeFormat = @doc.formats[format.config.exclude]
-          if excludeFormat?
-            @node = excludeFormat.remove(@node)
-            delete @formats[format.config.exclude]
+        (Object.keys @formats).forEach (name) =>
+          removeFormat = @doc.formats[name]
+          if removeFormat?
+            @node = removeFormat.remove(@node)
+            delete @formats[name]
         @node = format.add(@node, value)
       if value
         @formats[name] = value

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -53,8 +53,13 @@ class Keyboard
       return true unless range?
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
+
       delta = new Delta().retain(range.start).insert('\n', line.formats).delete(range.end - range.start)
       @quill.updateContents(delta, Quill.sources.USER)
+
+      removeFormats = (Object.keys line.formats).filter (format) => line.doc.formats[format].config.clearOnNewline
+      removeFormats.forEach (format) => @quill.prepareFormat(format, false)
+
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)
         @toolbar.setActive(format, value) if @toolbar?

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -8,9 +8,9 @@ class Toolbar
     container: null
 
   @formats:
-    LINE    : { 'align', 'bullet', 'list' }
+    LINE    : { 'align', 'bullet', 'list', 'h1' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline' }
+    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'h1' }
     TOOLTIP : { 'image', 'link' }
 
   constructor: (@quill, @options) ->


### PR DESCRIPTION
I don't think it's very useful for @Magnetme/monolith  to review this, since it's all coffeescript and in an unknown project. 

I do need to publish this though for our own usage. We can do this to our private repo, or just to the public one. I have no problem just pushing it to the public repository, and I think @rogierslag would also prefer that because of ops.

cc @wouter-willems