### PR TITLE
Fix pasting bug

### DIFF
--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -137,7 +137,7 @@ class Normalizer
         dom(curNode).isolate(lineNode.parentNode)
         if !dom.LIST_TAGS[curNode.tagName]? or !curNode.firstChild
           dom(curNode).unwrap()
-          Normalizer.pullBlocks(lineNode)
+          lineNode = Normalizer.pullBlocks(lineNode)
         else
           dom(curNode.parentNode).unwrap()
           lineNode = curNode unless lineNode.parentNode?    # May have just unwrapped lineNode


### PR DESCRIPTION
Normalizer.pullBlocks can replace lineNode, so we need to continue with
the result instead of just calling it.

I'm not going to bother anyone for a review here, it's a one liner and impossible to review without understanding what the thing does.