### PR TITLE
Move ownership to magnet.me

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mm-quill",
+  "name": "@magnet.me/mm-quill",
   "version": "1.0.2",
   "description": "Magnet.me specific fork of quill, a cross browser rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",


### PR DESCRIPTION
All our npm packages where currently still published under my own account, I'm now moving them to a shared Magnet.me account. I'll send usage instructions after the full migration is complete.